### PR TITLE
feat: add multi-tenant offline-first pos frontend

### DIFF
--- a/apps/pos/app/(auth)/login/page.tsx
+++ b/apps/pos/app/(auth)/login/page.tsx
@@ -1,0 +1,46 @@
+'use client';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+import { useAuth } from '../../../src/hooks/useAuth';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const { login } = useAuth();
+  const [merchant, setMerchant] = useState('');
+  const [token, setToken] = useState('');
+  const [role, setRole] = useState<'admin' | 'cashier' | 'waiter'>('waiter');
+
+  const submit = () => {
+    login(token, role);
+    router.push(`/${merchant}/menu`);
+  };
+
+  return (
+    <div className="max-w-sm mx-auto p-4 space-y-2">
+      <input
+        className="border p-2 w-full"
+        placeholder="Merchant"
+        value={merchant}
+        onChange={e => setMerchant(e.target.value)}
+      />
+      <input
+        className="border p-2 w-full"
+        placeholder="Token"
+        value={token}
+        onChange={e => setToken(e.target.value)}
+      />
+      <select
+        className="border p-2 w-full"
+        value={role}
+        onChange={e => setRole(e.target.value as any)}
+      >
+        <option value="admin">Admin</option>
+        <option value="cashier">Cashier</option>
+        <option value="waiter">Waiter</option>
+      </select>
+      <button onClick={submit} className="bg-blue-600 text-white px-4 py-2 rounded w-full">
+        Login
+      </button>
+    </div>
+  );
+}

--- a/apps/pos/app/[merchant]/admin/devices/page.tsx
+++ b/apps/pos/app/[merchant]/admin/devices/page.tsx
@@ -1,0 +1,40 @@
+'use client';
+import { useState } from 'react';
+import { useAuth } from '../../../../src/hooks/useAuth';
+import { apiFetch } from '../../../../src/lib/api';
+import { useOfflineSync } from '../../../../src/hooks/useOfflineSync';
+
+export default function DevicesPage({ params }: { params: { merchant: string } }) {
+  const { role } = useAuth();
+  const { merchant } = params;
+  const submit = useOfflineSync(merchant);
+  const [name, setName] = useState('');
+
+  if (role !== 'admin') return <div>Access denied</div>;
+
+  const register = async () => {
+    await submit('/devices', { method: 'POST', body: JSON.stringify({ name }) });
+    setName('');
+  };
+
+  const testPrint = () => {
+    apiFetch(merchant, '/printers/test', { method: 'POST' });
+  };
+
+  return (
+    <div className="space-y-2">
+      <input
+        className="border p-2"
+        placeholder="Device name"
+        value={name}
+        onChange={e => setName(e.target.value)}
+      />
+      <button onClick={register} className="bg-blue-600 text-white px-4 py-2 rounded">
+        Register
+      </button>
+      <button onClick={testPrint} className="bg-gray-600 text-white px-4 py-2 rounded">
+        Test Print
+      </button>
+    </div>
+  );
+}

--- a/apps/pos/app/[merchant]/admin/page.tsx
+++ b/apps/pos/app/[merchant]/admin/page.tsx
@@ -1,0 +1,10 @@
+'use client';
+import { useAuth } from '../../../src/hooks/useAuth';
+
+export default function AdminHome({ params }: { params: { merchant: string } }) {
+  const { role } = useAuth();
+  if (role !== 'admin' && role !== 'cashier') {
+    return <div>Access denied</div>;
+  }
+  return <div>Admin Dashboard for {params.merchant}</div>;
+}

--- a/apps/pos/app/[merchant]/admin/stock/page.tsx
+++ b/apps/pos/app/[merchant]/admin/stock/page.tsx
@@ -1,0 +1,49 @@
+'use client';
+import { useEffect, useState } from 'react';
+import type { MenuItem } from '@qrorderpos/types';
+import { apiFetch } from '../../../../src/lib/api';
+import { useOfflineSync } from '../../../../src/hooks/useOfflineSync';
+import { useAuth } from '../../../../src/hooks/useAuth';
+
+interface StockItem {
+  id: string;
+  name: string;
+  stock: number;
+}
+
+export default function StockPage({ params }: { params: { merchant: string } }) {
+  const { role } = useAuth();
+  if (role !== 'admin' && role !== 'cashier') return <div>Access denied</div>;
+  const { merchant } = params;
+  const [items, setItems] = useState<StockItem[]>([]);
+  const submit = useOfflineSync(merchant);
+
+  useEffect(() => {
+    apiFetch<StockItem[]>(merchant, '/items/stock').then(setItems);
+  }, [merchant]);
+
+  const adjust = async (id: string, delta: number) => {
+    setItems(prev => prev.map(it => (it.id === id ? { ...it, stock: it.stock + delta } : it)));
+    await submit('/stock-adjustments', {
+      method: 'POST',
+      body: JSON.stringify({ itemId: id, delta })
+    });
+  };
+
+  return (
+    <div className="space-y-2">
+      {items.map(it => (
+        <div key={it.id} className="flex justify-between items-center border p-2 rounded">
+          <div>
+            <div className="font-bold">{it.name}</div>
+            <div className="text-sm">Stock: {it.stock}</div>
+          </div>
+          <div className="space-x-2">
+            <button onClick={() => adjust(it.id, 1)} className="px-2 py-1 bg-green-600 text-white rounded">+1</button>
+            <button onClick={() => adjust(it.id, -1)} className="px-2 py-1 bg-red-600 text-white rounded">-1</button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/pos/app/[merchant]/layout.tsx
+++ b/apps/pos/app/[merchant]/layout.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from 'react';
+import { Layout } from '../../src/components/Layout';
+
+export default function MerchantLayout({ params, children }: { params: { merchant: string }; children: ReactNode }) {
+  return <Layout merchant={params.merchant}>{children}</Layout>;
+}

--- a/apps/pos/app/[merchant]/menu/page.tsx
+++ b/apps/pos/app/[merchant]/menu/page.tsx
@@ -1,0 +1,42 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { apiFetch } from '../../../src/lib/api';
+import { openDB } from 'idb';
+import type { MenuItem } from '@qrorderpos/types';
+
+export default function MenuPage({ params }: { params: { merchant: string } }) {
+  const { merchant } = params;
+  const [menu, setMenu] = useState<MenuItem[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      const db = await openDB('qrpos', 1, {
+        upgrade(db) {
+          db.createObjectStore('menu');
+        }
+      });
+      try {
+        const data = await apiFetch<MenuItem[]>(merchant, '/menu');
+        setMenu(data);
+        const tx = db.transaction('menu', 'readwrite');
+        await tx.store.put(data, merchant);
+        await tx.done;
+      } catch {
+        const cached = await db.get('menu', merchant);
+        if (cached) setMenu(cached as MenuItem[]);
+      }
+    };
+    load();
+  }, [merchant]);
+
+  return (
+    <div className="space-y-2">
+      {menu.map(item => (
+        <div key={item.id} className="border p-2 rounded">
+          <div className="font-bold">{item.name}</div>
+          <div>{item.price}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/pos/app/[merchant]/waiter/page.tsx
+++ b/apps/pos/app/[merchant]/waiter/page.tsx
@@ -1,0 +1,56 @@
+'use client';
+import { useEffect, useState } from 'react';
+import type { MenuItem } from '@qrorderpos/types';
+import { apiFetch } from '../../../src/lib/api';
+import { useOfflineSync } from '../../../src/hooks/useOfflineSync';
+
+export default function WaiterPage({ params }: { params: { merchant: string } }) {
+  const { merchant } = params;
+  const [menu, setMenu] = useState<MenuItem[]>([]);
+  const [items, setItems] = useState<Record<string, number>>({});
+  const submit = useOfflineSync(merchant);
+
+  useEffect(() => {
+    apiFetch<MenuItem[]>(merchant, '/menu').then(setMenu);
+  }, [merchant]);
+
+  const placeOrder = async () => {
+    const orderItems = Object.entries(items).map(([id, qty]) => ({ id, qty }));
+    await submit('/orders', {
+      method: 'POST',
+      body: JSON.stringify({ items: orderItems })
+    });
+    setItems({});
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-2">
+        {menu.map(item => (
+          <button
+            key={item.id}
+            onClick={() => setItems(s => ({ ...s, [item.id]: (s[item.id] || 0) + 1 }))}
+            className="border p-2 rounded"
+          >
+            {item.name}
+          </button>
+        ))}
+      </div>
+      <div>
+        <h3 className="font-bold mb-2">Current Order</h3>
+        {Object.entries(items).map(([id, qty]) => {
+          const item = menu.find(m => m.id === id);
+          return (
+            <div key={id} className="flex justify-between">
+              <span>{item?.name}</span>
+              <span>{qty}</span>
+            </div>
+          );
+        })}
+      </div>
+      <button onClick={placeOrder} className="bg-green-600 text-white px-4 py-2 rounded">
+        Send Order
+      </button>
+    </div>
+  );
+}

--- a/apps/pos/app/globals.css
+++ b/apps/pos/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html[dir="rtl"] {
+  direction: rtl;
+}

--- a/apps/pos/app/layout.tsx
+++ b/apps/pos/app/layout.tsx
@@ -1,0 +1,17 @@
+import './globals.css';
+import type { ReactNode } from 'react';
+import { ClientProviders } from '../src/components/ClientProviders';
+
+export const metadata = {
+  title: 'QR Order POS'
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <ClientProviders>{children}</ClientProviders>
+      </body>
+    </html>
+  );
+}

--- a/apps/pos/next-env.d.ts
+++ b/apps/pos/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/apps/pos/next.config.mjs
+++ b/apps/pos/next.config.mjs
@@ -1,0 +1,14 @@
+import withPWA from 'next-pwa';
+
+const nextConfig = {
+  reactStrictMode: true,
+  swcMinify: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+export default withPWA({
+  dest: 'public',
+  disable: process.env.NODE_ENV === 'development'
+})(nextConfig);

--- a/apps/pos/package.json
+++ b/apps/pos/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@qrorderpos/pos",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "next": "14.2.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "idb": "7.1.1",
+    "zustand": "4.4.1",
+    "@qrorderpos/api-client": "workspace:*",
+    "@qrorderpos/types": "workspace:*",
+    "uuid": "9.0.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "tailwindcss": "^3.4.1",
+    "postcss": "^8.4.31",
+    "autoprefixer": "^10.4.16",
+    "vitest": "^1.3.1",
+    "@types/react": "18.2.40",
+    "@types/node": "20.11.24"
+  }
+}

--- a/apps/pos/postcss.config.cjs
+++ b/apps/pos/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apps/pos/public/manifest.json
+++ b/apps/pos/public/manifest.json
@@ -1,0 +1,12 @@
+{
+  "name": "QR Order POS",
+  "short_name": "QRPOS",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#2563eb",
+  "icons": [
+    { "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/icon-512.png", "sizes": "512x512", "type": "image/png" }
+  ]
+}

--- a/apps/pos/public/sw.js
+++ b/apps/pos/public/sw.js
@@ -1,0 +1,25 @@
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open('qrpos-static').then(cache => cache.addAll(['/manifest.json']))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  const { request } = event;
+  if (request.method !== 'GET') return;
+  event.respondWith(
+    caches.match(request).then(cached =>
+      cached || fetch(request).then(res => {
+        const copy = res.clone();
+        caches.open('qrpos-dynamic').then(cache => cache.put(request, copy));
+        return res;
+      })
+    )
+  );
+});
+
+self.addEventListener('sync', event => {
+  if (event.tag === 'sync-outbox') {
+    event.waitUntil(self.syncOutbox && self.syncOutbox());
+  }
+});

--- a/apps/pos/src/components/ClientProviders.tsx
+++ b/apps/pos/src/components/ClientProviders.tsx
@@ -1,0 +1,14 @@
+'use client';
+import { useEffect } from 'react';
+import { useLocale } from '../hooks/useLocale';
+
+export function ClientProviders({ children }: { children: React.ReactNode }) {
+  const { locale } = useLocale();
+  useEffect(() => {
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('/sw.js');
+    }
+    document.documentElement.dir = locale === 'ur' ? 'rtl' : 'ltr';
+  }, [locale]);
+  return children as any;
+}

--- a/apps/pos/src/components/Layout.tsx
+++ b/apps/pos/src/components/Layout.tsx
@@ -1,0 +1,48 @@
+'use client';
+import Link from 'next/link';
+import { ReactNode } from 'react';
+import { useAuth } from '../hooks/useAuth';
+import { OfflineIndicator } from './OfflineIndicator';
+import { useLocale } from '../hooks/useLocale';
+import { t } from '../lib/i18n';
+
+export function Layout({ merchant, children }: { merchant: string; children: ReactNode }) {
+  const { role, logout } = useAuth();
+  const { locale, setLocale } = useLocale();
+  const links = [
+    { href: `/${merchant}/menu`, label: t(locale, 'menu'), roles: ['waiter', 'admin', 'cashier'] },
+    { href: `/${merchant}/waiter`, label: t(locale, 'order'), roles: ['waiter'] },
+    { href: `/${merchant}/admin`, label: 'Admin', roles: ['admin', 'cashier'] }
+  ];
+  return (
+    <div className="min-h-screen flex">
+      <OfflineIndicator />
+      <aside className="w-48 bg-gray-800 text-white p-4 space-y-4">
+        <h2 className="text-lg font-bold">QRPOS</h2>
+        <nav className="space-y-2">
+          {links
+            .filter(l => !role || l.roles.includes(role))
+            .map(link => (
+              <Link key={link.href} href={link.href} className="block hover:underline">
+                {link.label}
+              </Link>
+            ))}
+        </nav>
+        <div className="space-x-2 text-sm">
+          <button onClick={() => setLocale('en')} className={locale === 'en' ? 'underline' : ''}>
+            EN
+          </button>
+          <button onClick={() => setLocale('ur')} className={locale === 'ur' ? 'underline' : ''}>
+            \u0627\u0631\u062f\u0648
+          </button>
+        </div>
+        {role && (
+          <button onClick={logout} className="mt-4 text-sm underline">
+            {t(locale, 'logout')}
+          </button>
+        )}
+      </aside>
+      <main className="flex-1 p-4">{children}</main>
+    </div>
+  );
+}

--- a/apps/pos/src/components/OfflineIndicator.tsx
+++ b/apps/pos/src/components/OfflineIndicator.tsx
@@ -1,0 +1,22 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export function OfflineIndicator() {
+  const [offline, setOffline] = useState(!navigator.onLine);
+  useEffect(() => {
+    const on = () => setOffline(false);
+    const off = () => setOffline(true);
+    window.addEventListener('online', on);
+    window.addEventListener('offline', off);
+    return () => {
+      window.removeEventListener('online', on);
+      window.removeEventListener('offline', off);
+    };
+  }, []);
+  if (!offline) return null;
+  return (
+    <div className="bg-yellow-500 text-black text-center py-1 text-sm">
+      Offline mode - changes will sync when back online
+    </div>
+  );
+}

--- a/apps/pos/src/hooks/useAuth.ts
+++ b/apps/pos/src/hooks/useAuth.ts
@@ -1,0 +1,16 @@
+'use client';
+import { create } from 'zustand';
+
+interface AuthState {
+  token: string | null;
+  role: 'admin' | 'cashier' | 'waiter' | null;
+  login: (token: string, role: AuthState['role']) => void;
+  logout: () => void;
+}
+
+export const useAuth = create<AuthState>(set => ({
+  token: null,
+  role: null,
+  login: (token, role) => set({ token, role }),
+  logout: () => set({ token: null, role: null })
+}));

--- a/apps/pos/src/hooks/useLocale.ts
+++ b/apps/pos/src/hooks/useLocale.ts
@@ -1,0 +1,13 @@
+'use client';
+import { create } from 'zustand';
+import type { Locale } from '../lib/i18n';
+
+interface LocaleState {
+  locale: Locale;
+  setLocale: (l: Locale) => void;
+}
+
+export const useLocale = create<LocaleState>(set => ({
+  locale: 'en',
+  setLocale: locale => set({ locale })
+}));

--- a/apps/pos/src/hooks/useOfflineSync.ts
+++ b/apps/pos/src/hooks/useOfflineSync.ts
@@ -1,0 +1,31 @@
+'use client';
+import { useEffect } from 'react';
+import { enqueue, flush } from '../lib/offlineQueue';
+import { apiFetch } from '../lib/api';
+
+export function useOfflineSync(merchant: string) {
+  useEffect(() => {
+    navigator.serviceWorker?.addEventListener('message', () => {
+      flush(item => apiFetch(item.merchant, item.url, item.options));
+    });
+    window.addEventListener('online', () => {
+      flush(item => apiFetch(item.merchant, item.url, item.options));
+    });
+  }, [merchant]);
+
+  return async function submit(url: string, options: RequestInit) {
+    try {
+      await apiFetch(merchant, url, options);
+    } catch (err) {
+      await enqueue({
+        id: crypto.randomUUID(),
+        merchant,
+        url,
+        options
+      });
+      navigator.serviceWorker?.ready.then(sw =>
+        sw.sync.register('sync-outbox')
+      );
+    }
+  };
+}

--- a/apps/pos/src/lib/api.ts
+++ b/apps/pos/src/lib/api.ts
@@ -1,0 +1,29 @@
+import { v4 as uuidv4 } from 'uuid';
+
+const clientUuid = (() => {
+  if (typeof localStorage === 'undefined') return 'server';
+  let id = localStorage.getItem('client_uuid');
+  if (!id) {
+    id = uuidv4();
+    localStorage.setItem('client_uuid', id);
+  }
+  return id;
+})();
+
+export async function apiFetch<T>(merchant: string, path: string, options: RequestInit = {}): Promise<T> {
+  const idempotencyKey = uuidv4();
+  const headers = {
+    'Content-Type': 'application/json',
+    'X-Client-UUID': clientUuid,
+    'Idempotency-Key': idempotencyKey,
+    ...(options.headers || {})
+  } as Record<string, string>;
+  const res = await fetch(`/merchants/${merchant}${path}`, {
+    ...options,
+    headers
+  });
+  if (!res.ok) {
+    throw new Error(await res.text());
+  }
+  return res.json() as Promise<T>;
+}

--- a/apps/pos/src/lib/i18n.ts
+++ b/apps/pos/src/lib/i18n.ts
@@ -1,0 +1,18 @@
+export type Locale = 'en' | 'ur';
+
+const translations: Record<Locale, Record<string, string>> = {
+  en: {
+    menu: 'Menu',
+    order: 'Order',
+    logout: 'Logout'
+  },
+  ur: {
+    menu: '\u0645\u06cc\u0646\u0648',
+    order: '\u0622\u0631\u0688\u0631',
+    logout: '\u0644\u0627\u06af \u0622\u0648\u0679'
+  }
+};
+
+export function t(locale: Locale, key: string) {
+  return translations[locale][key] || key;
+}

--- a/apps/pos/src/lib/offlineQueue.ts
+++ b/apps/pos/src/lib/offlineQueue.ts
@@ -1,0 +1,40 @@
+import { openDB } from 'idb';
+
+type OutboxItem = {
+  id: string;
+  merchant: string;
+  url: string;
+  options: RequestInit;
+};
+
+const DB_NAME = 'qrpos';
+const STORE_NAME = 'outbox';
+
+async function getDb() {
+  return openDB(DB_NAME, 1, {
+    upgrade(db) {
+      db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+    }
+  });
+}
+
+export async function enqueue(item: OutboxItem) {
+  const db = await getDb();
+  await db.put(STORE_NAME, item);
+}
+
+export async function flush(send: (item: OutboxItem) => Promise<void>) {
+  const db = await getDb();
+  const tx = db.transaction(STORE_NAME, 'readwrite');
+  const store = tx.store;
+  for await (const cursor of store) {
+    const item = cursor.value as OutboxItem;
+    try {
+      await send(item);
+      await cursor.delete();
+    } catch (err) {
+      console.error('Flush failed', err);
+    }
+  }
+  await tx.done;
+}

--- a/apps/pos/tailwind.config.ts
+++ b/apps/pos/tailwind.config.ts
@@ -1,0 +1,11 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./app/**/*.{ts,tsx}', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};
+
+export default config;

--- a/apps/pos/test/offlineQueue.test.ts
+++ b/apps/pos/test/offlineQueue.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { enqueue, flush } from '../src/lib/offlineQueue';
+
+vi.mock('idb', async () => {
+  const items: any = new Map();
+  return {
+    openDB: async () => ({
+      put: (_: string, item: any) => items.set(item.id, item),
+      transaction: () => ({
+        store: {
+          async *[Symbol.asyncIterator]() {
+            for (const id of Array.from(items.keys())) {
+              yield { value: items.get(id), delete: () => items.delete(id) } as any;
+            }
+          }
+        }
+      })
+    })
+  };
+});
+
+describe('offline queue', () => {
+  beforeEach(async () => {
+    // reset mocked storage
+  });
+
+  it('enqueues and flushes', async () => {
+    const send = vi.fn().mockResolvedValue(undefined);
+    await enqueue({ id: '1', merchant: 'm', url: '/x', options: { method: 'POST' } });
+    await flush(send);
+    expect(send).toHaveBeenCalled();
+  });
+});

--- a/apps/pos/tsconfig.json
+++ b/apps/pos/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "jsx": "preserve",
+    "moduleResolution": "node",
+    "allowJs": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "target": "esnext",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "types": ["next", "next/types/global", "vitest/globals"]
+  },
+  "include": ["next-env.d.ts", "src/**/*", "app/**/*", "test/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js PWA for POS with Tailwind and service worker
- add IndexedDB offline outbox and sync utilities
- implement role-based views for waiter, admin stock, and device management

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-9.0.0.tgz)*

------
https://chatgpt.com/codex/tasks/task_b_68c54e867fe883258060077a55544831